### PR TITLE
[format] Improve readability by fixing various naming conventions / typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The `image` and `language` folders are for complex model applications. The `feat
 ## Discussion
 
 Discussion about the Colossal-AI project and examples is always welcomed! We would love to exchange ideas with the community to better help this project grow.
-If you think there is a need to discuss anything, you may jump to our [dicussion forum](https://github.com/hpcaitech/ColossalAI/discussions) and create a topic there.
+If you think there is a need to discuss anything, you may jump to our [discussion forum](https://github.com/hpcaitech/ColossalAI/discussions) and create a topic there.
 
 If you encounter any problem while running these examples, you may want to raise an issue in this repository.
 
@@ -88,9 +88,9 @@ If you find that an example is broken (not working) or not user-friendly, you ma
 
 If you wish to add an example for a specific application, please follow the steps below.
 
-1. create a folder in the `image`, `language` or `features` folders. Generally we do not accept new examples for `features` as one example is often enough. **We encourage contribution with hybrid parallel or models of different domains (e.g. GAN, self-supervised, detection, video understadning, text classification, text generation)**
+1. create a folder in the `image`, `language` or `features` folders. Generally we do not accept new examples for `features` as one example is often enough. **We encourage contribution with hybrid parallel or models of different domains (e.g. GAN, self-supervised, detection, video understanding, text classification, text generation)**
 2. Prepare configuration files and `train.py`
-3. Prepare a detailed readme on envirionment setup, dataset preparation, code execution, etc. in your example folder
+3. Prepare a detailed readme on environment setup, dataset preparation, code execution, etc. in your example folder
 4. Update the table of content (first section above) in this readme file
 
 

--- a/benchmark/zero/common/train.py
+++ b/benchmark/zero/common/train.py
@@ -15,7 +15,7 @@ def _train(epoch, rank, world_size, train_dataloader, model, criterion, optimize
     use_autocast = CONFIG['method'] in ['torch', 'colossalai'] and \
         'fp16' in CONFIG and CONFIG['fp16'].get('enabled', True)
     clip_grad_norm = CONFIG.get('gradient_clipping', 0.)
-    use_integraded_clip_grad = CONFIG['method'] in ['fairscale']
+    use_integrated_clip_grad = CONFIG['method'] in ['fairscale']
     use_colossalai_zero_v1 = CONFIG['method'] == 'colossalai' and CONFIG.get('sharded_model_version', 2) == 1
 
     model.train()
@@ -103,7 +103,7 @@ def _train(epoch, rank, world_size, train_dataloader, model, criterion, optimize
             scaler.scale(loss).backward()
             scaler.unscale_(optimizer)
             if clip_grad_norm > 0:
-                if use_integraded_clip_grad:    # fairscale style
+                if use_integrated_clip_grad:    # fairscale style
                     model.clip_grad_norm_(clip_grad_norm)
                 else:    # torch style
                     torch.nn.utils.clip_grad_norm_(model.parameters(), clip_grad_norm)
@@ -114,7 +114,7 @@ def _train(epoch, rank, world_size, train_dataloader, model, criterion, optimize
         else:    # torch & fairscale normal style
             loss.backward()
             if clip_grad_norm > 0:
-                if use_integraded_clip_grad:    # fairscale style
+                if use_integrated_clip_grad:    # fairscale style
                     model.clip_grad_norm_(clip_grad_norm)
                 else:    # torch style
                     torch.nn.utils.clip_grad_norm_(model.parameters(), clip_grad_norm)

--- a/benchmark/zero/common/vit.py
+++ b/benchmark/zero/common/vit.py
@@ -144,7 +144,7 @@ def build_data():
                                        interp_type=types.INTERP_TRIANGULAR)
                     flip_lr = False
 
-                # center crop and normalise
+                # center crop and normalize
                 images = fn.crop_mirror_normalize(images,
                                                   dtype=types.FLOAT,
                                                   crop=(crop, crop),

--- a/features/amp/README.md
+++ b/features/amp/README.md
@@ -6,7 +6,7 @@ You may refer to [our documentation on mixed precision training](https://colossa
 
 > ⚠️ This example is only for demo purpose, no guarantee on the convergence performance
 
-# Prerequiste
+# Prerequisite
 
 ```shell
 pip install timm scipy

--- a/features/amp/train.py
+++ b/features/amp/train.py
@@ -61,7 +61,7 @@ def main():
     # build loss
     criterion = torch.nn.CrossEntropyLoss()
 
-    # lr_scheduelr
+    # lr_scheduler
     lr_scheduler = LinearWarmupLR(optimizer, warmup_steps=1, total_steps=gpc.config.NUM_EPOCHS)
 
     engine, train_dataloader, _, _ = colossalai.initialize(

--- a/features/gradient_clipping/README.md
+++ b/features/gradient_clipping/README.md
@@ -19,7 +19,7 @@ export DATA=/path/to/data
 
 ## Verify Gradient Clipping
 
-To verify gradinet clipping, we can just check the change of parameter values.  
+To verify gradient clipping, we can just check the change of parameter values.  
 
 ```bash
 colossalai run --nproc_per_node 1 train.py

--- a/features/tensor_parallel/README.md
+++ b/features/tensor_parallel/README.md
@@ -5,7 +5,7 @@
 To use tensor parallelism, there are several steps to follow:
 
 1. define `parallel` in your configuration file. Set `mode` for `tensor` to `1d`, `2d`, `2.5d` or `3d`.
-2. cosntruct your model, replace `torch.nn.Linear` with `colossalai.nn.Linear`.
+2. construct your model, replace `torch.nn.Linear` with `colossalai.nn.Linear`.
 3. split the input data accordingly
 
 ## Reference

--- a/image/detr/README.md
+++ b/image/detr/README.md
@@ -4,7 +4,7 @@ Reproduce the DETR model with ColossalAI
 ## Background
 This project is the reproduction of [DETR model](https://arxiv.org/abs/2005.12872) with [ColossalAI](https://github.com/hpcaitech/ColossalAI) tool.
 
-## Envirionment setup
+## Environment setup
 ```
 git clone https://github.com/hpcaitech/ColossalAI.git
 cd ColossalAI

--- a/image/detr/models/matcher.py
+++ b/image/detr/models/matcher.py
@@ -65,7 +65,7 @@ class HungarianMatcher(nn.Module):
 
         # Compute the classification cost. Contrary to the loss, we don't use the NLL,
         # but approximate it in 1 - proba[target class].
-        # The 1 is a constant that doesn't change the matching, it can be ommitted.
+        # The 1 is a constant that doesn't change the matching, it can be omitted.
         cost_class = -out_prob[:, tgt_ids]
 
         # Compute the L1 cost between boxes

--- a/image/detr/util/misc.py
+++ b/image/detr/util/misc.py
@@ -257,7 +257,7 @@ class MetricLogger(object):
 #         sha = _run(['git', 'rev-parse', 'HEAD'])
 #         subprocess.check_output(['git', 'diff'], cwd=cwd)
 #         diff = _run(['git', 'diff-index', 'HEAD'])
-#         diff = "has uncommited changes" if diff else "clean"
+#         diff = "has uncomitted changes" if diff else "clean"
 #         branch = _run(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
 #     except Exception:
 #         pass

--- a/image/moe/README.md
+++ b/image/moe/README.md
@@ -7,12 +7,12 @@ It is designed to improve the performance of our models without any additional t
 version moe parallelism will cause a moderate computation overhead and additional memory usage. But
 we are happy to announce that recently enabled CUDA kernels have solved the problem above. There 
 are only two things that you need to concern. One is the additional communication time which highly
-depends on the topology and bandwith of the network in running environment. Another is extra memory usgae,
+depends on the topology and bandwidth of the network in running environment. Another is extra memory usage,
 since we have a larger model thanks to MoE. We will continuously maintain and optimize our MoE system
 and be encouraged by any issue that can help us improve our system.
 
 At present, we have provided Widenet and ViT-MoE in our model zoo (more information about Widenet can be 
-found [here](https://arxiv.org/abs/2107.11817)). We now support a recent tecnique proposed by Microsoft, PR-MoE.
+found [here](https://arxiv.org/abs/2107.11817)). We now support a recent technique proposed by Microsoft, PR-MoE.
 You can access [here](https://arxiv.org/abs/2201.05596) to know more about PR-MoE.
 Directly use ViT-MoE in our model zoo or use MoeModule in your model to exploit PR-MoE.
 

--- a/image/simclr/train_linear.py
+++ b/image/simclr/train_linear.py
@@ -59,7 +59,7 @@ def main():
     # build optimizer
     optimizer = colossalai.nn.FusedSGD(model.parameters(), lr=gpc.config.LEARNING_RATE, weight_decay=gpc.config.WEIGHT_DECAY, momentum=gpc.config.MOMENTUM)
     
-    # lr_scheduelr
+    # lr_scheduler
     lr_scheduler = CosineAnnealingWarmupLR(optimizer, warmup_steps=5, total_steps=gpc.config.NUM_EPOCHS)
 
     engine, train_dataloader, test_dataloader, _ = colossalai.initialize(

--- a/image/simclr/train_simclr.py
+++ b/image/simclr/train_simclr.py
@@ -64,7 +64,7 @@ def main():
     optimizer = colossalai.nn.FusedSGD(model.parameters(), lr=gpc.config.LEARNING_RATE,
                                        weight_decay=gpc.config.WEIGHT_DECAY, momentum=gpc.config.MOMENTUM)
 
-    # lr_scheduelr
+    # lr_scheduler
     lr_scheduler = CosineAnnealingWarmupLR(optimizer, warmup_steps=10, total_steps=gpc.config.NUM_EPOCHS)
 
     engine, train_dataloader, test_dataloader, _ = colossalai.initialize(

--- a/image/vilt/utils/objectives.py
+++ b/image/vilt/utils/objectives.py
@@ -7,7 +7,7 @@ import json
 
 
 def cost_matrix_cosine(x, y, eps=1e-5):
-    """Compute cosine distnace across every pairs of x, y (batched)
+    """Compute cosine distance across every pairs of x, y (batched)
     [B, L_x, D] [B, L_y, D] -> [B, Lx, Ly]"""
     assert x.dim() == y.dim()
     assert x.size(0) == y.size(0)

--- a/image/vilt/utils/transforms/randaug.py
+++ b/image/vilt/utils/transforms/randaug.py
@@ -1,4 +1,4 @@
-# code in this file is adpated from rpmcruz/autoaugment
+# code in this file is adapted from rpmcruz/autoaugment
 # https://github.com/rpmcruz/autoaugment/blob/master/transformations.py
 import random
 
@@ -158,7 +158,7 @@ def Identity(img, v):
     return img
 
 
-def augment_list():  # 16 oeprations and their ranges
+def augment_list():  # 16 operations and their ranges
     # https://github.com/google-research/uda/blob/master/image/randaugment/policies.py#L57
     # l = [
     #     (Identity, 0., 1.0),

--- a/image/vision_transformer/data_parallel/README.md
+++ b/image/vision_transformer/data_parallel/README.md
@@ -48,7 +48,7 @@ As can be seen from the above figure, the ViT model eventually converges well af
 # Details
 `config.py`
 
-This is a [configuration file](https://colossalai.org/config.html) that defines hyperparameters and trainign scheme (fp16, gradient accumulation, etc.). The config content can be accessed through `gpc.config` in the program.
+This is a [configuration file](https://colossalai.org/config.html) that defines hyperparameters and training scheme (fp16, gradient accumulation, etc.). The config content can be accessed through `gpc.config` in the program.
 
 In this example, we trained ViT-Base/16 for 300 epochs on the ImageNet-1K dataset. The batch size is expanded to 32K through data parallelism. Since only 4 A100 GPUs on one small server are used, and the GPU memory is limited, the batch size of 32K cannot be used directly. Therefore, the batch size used on each GPU is only 256, and the 256 batch size is equivalently expanded to 8K through gradient accumulation 32 times. Finally, data parallelism is used between 4 GPUs to achieve an equivalent batch size of 32K.
 

--- a/image/vision_transformer/data_parallel/train.py
+++ b/image/vision_transformer/data_parallel/train.py
@@ -45,7 +45,7 @@ def main():
     # build loss
     criterion = MixupLoss(loss_fn_cls=torch.nn.CrossEntropyLoss)
 
-    # lr_scheduelr
+    # lr_scheduler
     lr_scheduler = LinearWarmupLR(optimizer, warmup_steps=1, total_steps=gpc.config.NUM_EPOCHS)
 
     engine, train_dataloader, test_dataloader, _ = colossalai.initialize(model, optimizer, criterion, train_dataloader,

--- a/image/vision_transformer/data_parallel/train_with_cifar10.py
+++ b/image/vision_transformer/data_parallel/train_with_cifar10.py
@@ -40,7 +40,7 @@ def main():
     # build loss
     criterion = torch.nn.CrossEntropyLoss()
 
-    # lr_scheduelr
+    # lr_scheduler
     lr_scheduler = LinearWarmupLR(optimizer, warmup_steps=50, total_steps=gpc.config.NUM_EPOCHS)
 
     engine, train_dataloader, test_dataloader, _ = colossalai.initialize(model, optimizer, criterion, train_dataloader,

--- a/image/vision_transformer/hybrid_parallel/train_with_cifar10.py
+++ b/image/vision_transformer/hybrid_parallel/train_with_cifar10.py
@@ -68,7 +68,7 @@ def main():
         pipeline_stage = gpc.get_local_rank(ParallelMode.PIPELINE)
     logger.info(f"number of parameters: {total_numel} on pipeline stage {pipeline_stage}")
 
-    # craete dataloaders
+    # create dataloaders
     root = os.environ.get('DATA', './data')
     train_dataloader, test_dataloader = build_cifar(gpc.config.BATCH_SIZE, root, pad_if_needed=True)
 
@@ -83,7 +83,7 @@ def main():
                                            total_steps=gpc.config.NUM_EPOCHS,
                                            warmup_steps=gpc.config.WARMUP_EPOCHS)
 
-    # intiailize
+    # initialize
     engine, train_dataloader, test_dataloader, _ = colossalai.initialize(model=model,
                                                                          optimizer=optimizer,
                                                                          criterion=criterion,

--- a/image/vision_transformer/hybrid_parallel/train_with_engine.py
+++ b/image/vision_transformer/hybrid_parallel/train_with_engine.py
@@ -69,7 +69,7 @@ def train_imagenet():
         pipeline_stage = gpc.get_local_rank(ParallelMode.PIPELINE)
     logger.info(f"number of parameters: {total_numel} on pipeline stage {pipeline_stage}")
 
-    # craete dataloaders
+    # create dataloaders
     root = os.environ['DATA']
     train_dataloader, test_dataloader = build_dali_imagenet(root, rand_augment=False)
 
@@ -84,7 +84,7 @@ def train_imagenet():
                                            total_steps=gpc.config.NUM_EPOCHS,
                                            warmup_steps=gpc.config.WARMUP_EPOCHS)
 
-    # intiailize
+    # initialize
     engine, train_dataloader, test_dataloader, _ = colossalai.initialize(model=model,
                                                                          optimizer=optimizer,
                                                                          criterion=criterion,

--- a/image/vision_transformer/hybrid_parallel/train_with_trainer.py
+++ b/image/vision_transformer/hybrid_parallel/train_with_trainer.py
@@ -79,7 +79,7 @@ def train_imagenet():
                                            total_steps=gpc.config.NUM_EPOCHS,
                                            warmup_steps=gpc.config.WARMUP_EPOCHS)
 
-    # intiailize
+    # initialize
     engine, train_dataloader, test_dataloader, _ = colossalai.initialize(model=model,
                                                                          optimizer=optimizer,
                                                                          criterion=criterion,

--- a/language/bert/hybrid_parallel/colossalai_utils/model_zoo/colo_bert.py
+++ b/language/bert/hybrid_parallel/colossalai_utils/model_zoo/colo_bert.py
@@ -1,5 +1,5 @@
 """
-Adapted from huggingface modeling_bert.py. Change the necessary part to use Colossolai.
+Adapted from huggingface modeling_bert.py. Change the necessary part to use Colossalai.
 """
 import torch
 import math
@@ -644,7 +644,7 @@ class BertModel(BertPreTrainedModel):
         else:
             encoder_extended_attention_mask = None
 
-        ###print("BertModel:emeddings:", embedding_output.shape)
+        ###print("BertModel:embeddings:", embedding_output.shape)
         encoder_outputs = self.encoder(
             embedding_output,
             attention_mask=extended_attention_mask,

--- a/language/bert/hybrid_parallel/common/train.py
+++ b/language/bert/hybrid_parallel/common/train.py
@@ -15,7 +15,7 @@ def _train(epoch, rank, world_size, train_dataloader, model, criterion, optimize
     use_autocast = CONFIG['method'] in ['torch', 'colossalai'] and \
         'fp16' in CONFIG and CONFIG['fp16'].get('enabled', True)
     clip_grad_norm = CONFIG.get('gradient_clipping', 0.)
-    use_integraded_clip_grad = CONFIG['method'] in ['fairscale']
+    use_integrated_clip_grad = CONFIG['method'] in ['fairscale']
     use_colossalai_zero_v1 = CONFIG['method'] == 'colossalai' and CONFIG.get('sharded_model_version', 2) == 1
 
     model.train()

--- a/language/bert/sequene_parallel/README.md
+++ b/language/bert/sequene_parallel/README.md
@@ -124,7 +124,7 @@ make
 
 In the `config.py` provided, a set of parameters are defined including training scheme, model, etc.
 You can also modify the ColossalAI setting. For example, if you wish to parallelize over the 
-sequence diemsnion on 8 GPUs. You can change `size=4` to `size=8`. If you wish to use pipeline parallelism, you can set `pipeline=<num_of_pipeline_stages>`.
+sequence dimension on 8 GPUs. You can change `size=4` to `size=8`. If you wish to use pipeline parallelism, you can set `pipeline=<num_of_pipeline_stages>`.
 
 ### Step 4. Invoke parallel training
 

--- a/language/bert/sequene_parallel/data/__init__.py
+++ b/language/bert/sequene_parallel/data/__init__.py
@@ -28,7 +28,7 @@ def build_train_valid_test_data_iterators(train_iters,
     # Backward compatibility, assume fixed batch size.
     # if iteration > 0 and consumed_train_samples == 0:
     #     assert train_samples is None, \
-    #         'only backward compatiblity support for iteration-based training'
+    #         'only backward compatibility support for iteration-based training'
     #     consumed_train_samples = iteration * global_batch_size
     # if iteration > 0 and consumed_valid_samples == 0:
     #     if train_samples is None:
@@ -54,7 +54,7 @@ def build_train_valid_test_data_iterators(train_iters,
         train_ds, valid_ds, test_ds = build_train_valid_test_datasets(
             train_valid_test_num_samples=train_val_test_num_samples, **kwargs)
 
-        # Build dataloders.
+        # Build dataloaders.
         dp_size = gpc.get_world_size(ParallelMode.DATA)
         train_dataloader = build_pretraining_data_loader(
             train_ds, consumed_samples=0, micro_batch_size=global_batch_size//dp_size)

--- a/language/bert/sequene_parallel/data/bert_helper.py
+++ b/language/bert/sequene_parallel/data/bert_helper.py
@@ -53,7 +53,7 @@ def broadcast_data(keys, data, datatype):
     members of the same model parallel group.
 
     Arguments:
-        keys: list of keys in the data disctionary to be broadcasted
+        keys: list of keys in the data dictionary to be broadcasted
         data: data dictionary of string keys and cpu tensor values.
         datatype: torch data type of all tensors in data associated
                   with keys.

--- a/language/bert/sequene_parallel/data/datasets/bert_dataset.py
+++ b/language/bert/sequene_parallel/data/datasets/bert_dataset.py
@@ -73,7 +73,7 @@ class BertDataset(Dataset):
         sample = [self.indexed_dataset[i] for i in range(start_idx, end_idx)]
         # Note that this rng state should be numpy and not python since
         # python randint is inclusive whereas the numpy one is exclusive.
-        # We % 2**32 since numpy requres the seed to be between 0 and 2**32 - 1
+        # We % 2**32 since numpy requires the seed to be between 0 and 2**32 - 1
         np_rng = np.random.RandomState(seed=((self.seed + idx) % 2**32))
         return build_training_sample(
             sample,
@@ -126,16 +126,16 @@ def get_samples_mapping_(indexed_dataset, data_prefix, num_epochs, max_num_sampl
         # Build samples mapping
         verbose = torch.distributed.get_rank() == 0
         start_time = time.time()
-        logger.info('\n > building sapmles index mapping for {} ...'.format(name), ranks=[0])
+        logger.info('\n > building samples index mapping for {} ...'.format(name), ranks=[0])
         # First compile and then import.
         samples_mapping = helpers.build_mapping(indexed_dataset.doc_idx, indexed_dataset.sizes, num_epochs,
                                                 max_num_samples, max_seq_length, short_seq_prob, seed, verbose,
                                                 2 if binary_head else 1)
-        logger.info('\n > done building sapmles index maping', ranks=[0])
+        logger.info('\n > done building samples index maping', ranks=[0])
         np.save(indexmap_filename, samples_mapping, allow_pickle=True)
         logger.info('\n > saved the index mapping in {}'.format(indexmap_filename), ranks=[0])
         # Make sure all the ranks have built the mapping
-        logger.info('\n > elasped time to build and save samples mapping '
+        logger.info('\n > elapsed time to build and save samples mapping '
                     '(seconds): {:4f}'.format(time.time() - start_time),
                     ranks=[0])
     # This should be a barrier but nccl barrier assumes
@@ -161,7 +161,7 @@ def get_samples_mapping_(indexed_dataset, data_prefix, num_epochs, max_num_sampl
 
 def build_training_sample(sample, target_seq_length, max_seq_length, vocab_id_list, vocab_id_to_token_dict, cls_id,
                           sep_id, mask_id, pad_id, masked_lm_prob, np_rng, binary_head):
-    """Biuld training sample.
+    """Build training sample.
 
     Arguments:
         sample: A list of sentences in which each sentence is a list token ids.

--- a/language/bert/sequene_parallel/data/datasets/blendable_dataset.py
+++ b/language/bert/sequene_parallel/data/datasets/blendable_dataset.py
@@ -39,7 +39,7 @@ class BlendableDataset(torch.utils.data.Dataset):
         assert sum_weights > 0.0
         weights /= sum_weights
 
-        # Build indecies.
+        # Build indices.
         start_time = time.time()
         assert num_datasets < 255
         self.dataset_index = np.zeros(self.size, dtype=np.uint8)

--- a/language/bert/sequene_parallel/data/datasets/builder.py
+++ b/language/bert/sequene_parallel/data/datasets/builder.py
@@ -26,7 +26,7 @@ def _build_train_valid_test_datasets(data_prefix, data_impl, splits_string,
                                            skip_warmup)
 
     # Get start and end indices of train/valid/train into doc-idx
-    # Note that doc-idx is desinged to be num-docs + 1 so we can
+    # Note that doc-idx is designed to be num-docs + 1 so we can
     # easily iterate over it.
     total_num_of_documents = indexed_dataset.doc_idx.shape[0] - 1
     splits = get_train_valid_test_split_(splits_string, total_num_of_documents)

--- a/language/bert/sequene_parallel/data/datasets/data_samplers.py
+++ b/language/bert/sequene_parallel/data/datasets/data_samplers.py
@@ -21,7 +21,7 @@ from colossalai.context import ParallelMode
 
 
 def build_pretraining_data_loader(dataset, consumed_samples, micro_batch_size, dataloader_type='single', num_workers=0):
-    """Buld dataloader given an input dataset."""
+    """Build dataloader given an input dataset."""
 
     if dataset is None:
         return None

--- a/language/bert/sequene_parallel/data/datasets/dataset_utils.py
+++ b/language/bert/sequene_parallel/data/datasets/dataset_utils.py
@@ -218,7 +218,7 @@ def create_masked_lm_predictions(tokens,
                          max(1, int(round(len(tokens) * masked_lm_prob))))
 
     # Note(mingdachen):
-    # By default, we set the probilities to favor shorter ngram sequences.
+    # By default, we set the probabilities to favor shorter ngram sequences.
     ngrams = np.arange(1, max_ngrams + 1, dtype=np.int64)
     pvals = 1. / np.arange(1, max_ngrams + 1)
     pvals /= pvals.sum(keepdims=True)
@@ -463,7 +463,7 @@ def _build_train_valid_test_datasets(data_prefix, data_impl, splits_string,
                                              skip_warmup)
 
     # Get start and end indices of train/valid/train into doc-idx
-    # Note that doc-idx is desinged to be num-docs + 1 so we can
+    # Note that doc-idx is designed to be num-docs + 1 so we can
     # easily iterate over it.
     total_num_of_documents = indexed_dataset.doc_idx.shape[0] - 1
     splits = get_train_valid_test_split_(splits_string, total_num_of_documents)

--- a/language/bert/sequene_parallel/data/tokenizer/bert_tokenization.py
+++ b/language/bert/sequene_parallel/data/tokenizer/bert_tokenization.py
@@ -159,7 +159,7 @@ def whitespace_tokenize(text):
 
 
 class FullTokenizer(object):
-    """Runs end-to-end tokenziation."""
+    """Runs end-to-end tokenization."""
 
     def __init__(self, vocab_file, do_lower_case=True):
         self.vocab = load_vocab(vocab_file)
@@ -187,7 +187,7 @@ class FullTokenizer(object):
 
         def clean_up_tokenization(out_string):
             """ Clean up a list of simple English tokenization artifacts
-            like spaces before punctuations and abreviated forms.
+            like spaces before punctuations and abbreviated forms.
             """
             out_string = (
                 out_string.replace(" .", ".")
@@ -330,7 +330,7 @@ class BasicTokenizer(object):
 
 
 class WordpieceTokenizer(object):
-    """Runs WordPiece tokenziation."""
+    """Runs WordPiece tokenization."""
 
     def __init__(self, vocab, unk_token="[UNK]", max_input_chars_per_word=200):
         self.vocab = vocab
@@ -393,7 +393,7 @@ class WordpieceTokenizer(object):
 
 def _is_whitespace(char):
     """Checks whether `chars` is a whitespace character."""
-    # \t, \n, and \r are technically contorl characters but we treat them
+    # \t, \n, and \r are technically control characters but we treat them
     # as whitespace since they are generally considered as such.
     if char == " " or char == "\t" or char == "\n" or char == "\r":
         return True

--- a/language/bert/sequene_parallel/loss_func/cross_entropy.py
+++ b/language/bert/sequene_parallel/loss_func/cross_entropy.py
@@ -51,7 +51,7 @@ class _VocabCrossEntropy(torch.autograd.Function):
         # Retreive tensors from the forward path.
         softmax, target_mask, masked_target_1d = ctx.saved_tensors
 
-        # All the inputs have softmax as thier gradient.
+        # All the inputs have softmax as their gradient.
         grad_input = softmax
         # For simplicity, work with the 2D gradient.
         partition_vocab_size = softmax.size()[-1]

--- a/language/bert/sequene_parallel/loss_func/utils.py
+++ b/language/bert/sequene_parallel/loss_func/utils.py
@@ -39,7 +39,7 @@ def split_tensor_along_last_dim(tensor, num_partitions,
 class VocabUtility:
     """Split the vocabulary into `world_size` chunks amd return the
         first and last index of the vocabulary belonging to the `rank`
-        partition: Note that indecies in [fist, last)"""
+        partition: Note that indices in [fist, last)"""
 
     @staticmethod
     def vocab_range_from_per_partition_vocab_size(per_partition_vocab_size,

--- a/language/bert/sequene_parallel/model/bert.py
+++ b/language/bert/sequene_parallel/model/bert.py
@@ -18,7 +18,7 @@ class BertForPretrain(nn.Module):
                  vocab_size,
                  hidden_size,
                  max_sequence_length,
-                 num_attettion_heads,
+                 num_attention_heads,
                  num_layers,
                  add_binary_head,
                  is_naive_fp16,
@@ -49,7 +49,7 @@ class BertForPretrain(nn.Module):
         for i in range(num_layers):
             bert_layer = BertLayer(layer_number=i+1,
                                    hidden_size=hidden_size,
-                                   num_attention_heads=num_attettion_heads,
+                                   num_attention_heads=num_attention_heads,
                                    attention_dropout=dropout_prob,
                                    mlp_ratio=mlp_ratio,
                                    hidden_dropout=dropout_prob,
@@ -76,7 +76,7 @@ class BertForPretrain(nn.Module):
         if self.embedding.tokentype_embeddings:
             self._init_normal(self.embedding.tokentype_embeddings.weight)
 
-        # intiailize bert layer
+        # initialize bert layer
         for layer in self.bert_layers:
             # initialize self attention
             self._init_normal(layer.self_attention.query_key_value.weight)
@@ -84,7 +84,7 @@ class BertForPretrain(nn.Module):
             self._init_normal(layer.mlp.dense_h_to_4h.weight)
             self._output_init_normal(layer.mlp.dense_4h_to_h.weight)
 
-        # intializer head
+        # initializer head
         self._init_normal(self.head.lm_head.dense.weight)
         if self.head.binary_head is not None:
             self._init_normal(self.head.binary_head.pooler.dense.weight)
@@ -123,7 +123,7 @@ class PipelineBertForPretrain(nn.Module):
                  vocab_size,
                  hidden_size,
                  max_sequence_length,
-                 num_attettion_heads,
+                 num_attention_heads,
                  num_layers,
                  add_binary_head,
                  is_naive_fp16,
@@ -168,7 +168,7 @@ class PipelineBertForPretrain(nn.Module):
         for i in range(start_idx, end_idx):
             bert_layer = BertLayer(layer_number=i+1,
                                    hidden_size=hidden_size,
-                                   num_attention_heads=num_attettion_heads,
+                                   num_attention_heads=num_attention_heads,
                                    attention_dropout=dropout_prob,
                                    mlp_ratio=mlp_ratio,
                                    hidden_dropout=dropout_prob,
@@ -198,7 +198,7 @@ class PipelineBertForPretrain(nn.Module):
             if self.embedding.tokentype_embeddings:
                 self._init_normal(self.embedding.tokentype_embeddings.weight)
 
-        # intiailize bert layer
+        # initialize bert layer
         for layer in self.bert_layers:
             # initialize self attention
             self._init_normal(layer.self_attention.query_key_value.weight)
@@ -206,7 +206,7 @@ class PipelineBertForPretrain(nn.Module):
             self._init_normal(layer.mlp.dense_h_to_4h.weight)
             self._output_init_normal(layer.mlp.dense_4h_to_h.weight)
 
-        # intializer head
+        # initializer head
         if self.last_stage:
             self._init_normal(self.head.lm_head.dense.weight)
             if self.head.binary_head is not None:

--- a/language/bert/sequene_parallel/train.py
+++ b/language/bert/sequene_parallel/train.py
@@ -65,7 +65,7 @@ def main():
     kwargs = dict(vocab_size=VOCAB_SIZE,
                   hidden_size=gpc.config.HIDDEN_SIZE,
                   max_sequence_length=gpc.config.SEQ_LENGTH,
-                  num_attettion_heads=gpc.config.NUM_ATTENTION_HEADS,
+                  num_attention_heads=gpc.config.NUM_ATTENTION_HEADS,
                   convert_fp16_to_fp32_in_softmax=True,
                   is_naive_fp16=is_naive_fp16,
                   add_binary_head=gpc.config.ADD_BINARY_HEAD)

--- a/language/gpt/README.md
+++ b/language/gpt/README.md
@@ -8,7 +8,7 @@ In Colossal-AI, there are many ways to run GPT in a distributed manner. The `tra
 
 We do not host any datasets for GPT or BERT training, however, we provide a detailed guide on how to prepare the dataset so that our results may be reproduced.
 
-### Oveview
+### Overview
 We utilize the publicly available [OpenWebText](https://github.com/eukaryote31/openwebtext) library by [jcpeterson](https://github.com/jcpeterson/openwebtext) and  [eukaryote31's](https://github.com/eukaryote31/openwebtext) work to download urls to different web pages. We then filtered, cleaned, and deduplicated all downloaded content according to the procedure described in following section. 
 
 ### Install necessary packages
@@ -154,7 +154,7 @@ TENSOR_PARALLEL = 2
 
 You can modify it to use more tensor parallel, just with the general rules satisfied.
 In particular, `TENSOR_PARALLEL` should be a square number and cubic number for 2D and 3D, 
-respectively, and `TENSOR_PARALELL / DEPTH` should be a square number for 2.5D.
+respectively, and `TENSOR_PARALLEL / DEPTH` should be a square number for 2.5D.
 
 #### **Pipeline Parallel**
 
@@ -164,7 +164,7 @@ To use pipeline parallel training, you should install colossalai from the **late
 In `gpt2_pp.py`, there are lines:
 
 ```Python
-# BATCH_SIZE / NUM_MICRO_BATCHES should be an interger
+# BATCH_SIZE / NUM_MICRO_BATCHES should be an integer
 NUM_MICRO_BATCHES = 1
 PIPELINE = 2  
 ```

--- a/language/gpt/gpt2_configs/gpt2_2p5d.py
+++ b/language/gpt/gpt2_configs/gpt2_2p5d.py
@@ -6,7 +6,7 @@ from torch.optim import Adam
 BATCH_SIZE = 4
 SEQ_LEN = 1024
 NUM_EPOCHS = 60
-TERSOR_PARALLEL = 8
+TENSOR_PARALLEL = 8
 DEPTH = 2
 
 
@@ -32,5 +32,5 @@ model = dict(
 
 parallel = dict(
     pipeline=1,
-    tensor=dict(size=TERSOR_PARALLEL, depth=DEPTH, mode='2.5d'),
+    tensor=dict(size=TENSOR_PARALLEL, depth=DEPTH, mode='2.5d'),
 )

--- a/language/gpt/model/embed.py
+++ b/language/gpt/model/embed.py
@@ -195,7 +195,7 @@ class VocabParallelEmbedding1D(torch.nn.Module):
         # Keep the input dimensions.
         self.num_embeddings = num_embeddings
         self.embedding_dim = embedding_dim
-        # Set the detauls for compatibility.
+        # Set the details for compatibility.
         self.padding_idx = None
         self.max_norm = None
         self.norm_type = 2.
@@ -203,7 +203,7 @@ class VocabParallelEmbedding1D(torch.nn.Module):
         self.sparse = False
         self._weight = None
         self.tensor_model_parallel_size = gpc.tensor_parallel_size
-        # Divide the weight matrix along the vocaburaly dimension.
+        # Divide the weight matrix along the vocabulary dimension.
         self.vocab_start_index, self.vocab_end_index = \
             VocabUtility.vocab_range_from_global_vocab_size(
                 self.num_embeddings, gpc.get_local_rank(ParallelMode.PARALLEL_1D),
@@ -266,7 +266,7 @@ class _VocabParallelCrossEntropy(torch.autograd.Function):
         # Subtract the maximum value.
         vocab_parallel_logits.sub_(logits_max.unsqueeze(dim=-1))
 
-        # Get the partition's vocab indecies
+        # Get the partition's vocab indices
         get_vocab_range = VocabUtility.vocab_range_from_per_partition_vocab_size
         partition_vocab_size = vocab_parallel_logits.size()[-1]
         rank = gpc.get_local_rank(ParallelMode.PARALLEL_1D)
@@ -317,7 +317,7 @@ class _VocabParallelCrossEntropy(torch.autograd.Function):
         # Retreive tensors from the forward path.
         softmax, target_mask, masked_target_1d = ctx.saved_tensors
 
-        # All the inputs have softmax as thier gradient.
+        # All the inputs have softmax as their gradient.
         grad_input = softmax
         # For simplicity, work with the 2D gradient.
         partition_vocab_size = softmax.size()[-1]
@@ -338,7 +338,7 @@ class _VocabParallelCrossEntropy(torch.autograd.Function):
 class VocabUtility:
     """Split the vocabulary into `world_size` chunks amd return the
         first and last index of the vocabulary belonging to the `rank`
-        partition: Note that indecies in [fist, last)"""
+        partition: Note that indices in [fist, last)"""
 
     @staticmethod
     def vocab_range_from_per_partition_vocab_size(per_partition_vocab_size,
@@ -562,7 +562,7 @@ class HiddenParallelEmbedding1D(torch.nn.Module):
         self.num_embeddings = num_embeddings
         self.embedding_dim = embedding_dim
         embed_dim_per_partition = divide(embedding_dim, gpc.tensor_parallel_size)
-        # Set the detauls for compatibility.
+        # Set the details for compatibility.
         self.padding_idx = padding_idx
         self.max_norm = None
         self.norm_type = 2.

--- a/language/gpt/tools/Megatron/cleanup_dataset.py
+++ b/language/gpt/tools/Megatron/cleanup_dataset.py
@@ -24,7 +24,7 @@ import sys
 
 from tokenizer import Tokenizer
 
-MIN_DOCUMENT_LENGHT = 128
+MIN_DOCUMENT_LENGTH = 128
 
 
 def print_progress(prefix, start_time, num_docs, num_fixed_text,
@@ -75,9 +75,9 @@ def filter_corpus(filename, out_filename, print_interval=10000):
                         continue
                     # On average each token is 5 characters so 8 is an
                     # upper bound.
-                    if len(text) < (8 * MIN_DOCUMENT_LENGHT):
+                    if len(text) < (8 * MIN_DOCUMENT_LENGTH):
                         tokens = tokenizer.tokenize_document(text)
-                        if len(tokens) < MIN_DOCUMENT_LENGHT:
+                        if len(tokens) < MIN_DOCUMENT_LENGTH:
                             print('[small document, skipping]:', myjson)
                             num_small_docs += 1
                             chars_small_docs += len(text)

--- a/language/gpt/tools/Megatron/cleanup_fix_dataset.py
+++ b/language/gpt/tools/Megatron/cleanup_fix_dataset.py
@@ -44,7 +44,7 @@ def process_doc(json_line, args):
         'general_cleaning': False}
 
     try:
-        # Reomove all docs with less than 512 characters
+        # Remove all docs with less than 512 characters
         if "remove_512" in args.tasks:
             if len(text) < 512:
                 output['remove_512'] = True

--- a/language/gpt/tools/Megatron/find_duplicates.py
+++ b/language/gpt/tools/Megatron/find_duplicates.py
@@ -72,7 +72,7 @@ def url_pairs_to_remove(args, bucket_urls, url_doc):
         items = list(bucket_urls)
         remove_urls = []
         main_url = items[np.random.randint(0, len(items))]
-        main_dhingles = shingles(url_doc[main_url])
+        main_shingles = shingles(url_doc[main_url])
 
         for i in range(0, len(items)):
             counter_local += 1
@@ -81,7 +81,7 @@ def url_pairs_to_remove(args, bucket_urls, url_doc):
                 continue
             other_shingles = shingles(url_doc[other_url])
             try:
-                jaccard_sim = jaccard(main_dhingles, other_shingles, args)
+                jaccard_sim = jaccard(main_shingles, other_shingles, args)
             except Exception as e:
                 print('Error:', e)
                 jaccard_sim = 0.0
@@ -150,14 +150,14 @@ def find_pair_urls_parallel(args, lshcache, url_doc):
         counter += counter_local
         write_remove_urls_list(remove_urls_list, f_out)
         print(' [write]> processed {} documents in {:.2f} '
-            'seoncds and deduped {} documents ...'.format(counter, time.time()\
+            'seconds and deduped {} documents ...'.format(counter, time.time()\
             - start_time, deduped), flush=True)
 
     pool.close()
     pool.join()
     f_out.close()
 
-    print(' Taken time for jaccard similariries {:.2f} seconds'.format(\
+    print(' Taken time for jaccard similarities {:.2f} seconds'.format(\
         time.time() - start_time), flush=True)
 
 def find_pair_urls_sequential(args, lshcache, url_doc):
@@ -178,12 +178,12 @@ def find_pair_urls_sequential(args, lshcache, url_doc):
             write_remove_urls_list(remove_urls_list_sub, f_out)
             if counter % 10000 == 0:
                 print(' [write]> processed {} documents in {:.2f} '
-                    'seoncds and deduped {} documents ...'.
+                    'seconds and deduped {} documents ...'.
                     format(counter, time.time() - start_time,
                     deduped), flush=True)
     f_out.close()
     print(' [write]> processed {} documents in {:.2f} '
-        'seoncds and deduped {} documents ...'.
+        'seconds and deduped {} documents ...'.
         format(counter, time.time() - start_time,
         deduped), flush=True)
 

--- a/language/gpt/tools/Megatron/gpt2_tokenization.py
+++ b/language/gpt/tools/Megatron/gpt2_tokenization.py
@@ -58,7 +58,7 @@ def bytes_to_unicode():
     The reversible bpe codes work on unicode strings.
     This means you need a large # of unicode characters in your vocab if you want to avoid UNKs.
     When you're at something like a 10B token dataset you end up needing around 5K for decent coverage.
-    This is a signficant percentage of your normal, say, 32K bpe vocab.
+    This is a significant percentage of your normal, say, 32K bpe vocab.
     To avoid that, we want lookup tables between utf-8 bytes and unicode strings.
     And avoids mapping to whitespace/control characters the bpe code barfs on.
     """

--- a/language/knowledge_graph_embedding/train.py
+++ b/language/knowledge_graph_embedding/train.py
@@ -142,12 +142,12 @@ def main(args):
     colossalai.launch_from_torch(config=CONFIG)
 
     if (not args.do_train) and (not args.do_valid) and (not args.do_test):
-        raise ValueError('one of train/val/test mode must be choosed.')
+        raise ValueError('one of train/val/test mode must be chosen.')
 
     if args.init_checkpoint:
         override_config(args)
     elif args.data_path is None:
-        raise ValueError('one of init_checkpoint/data_path must be choosed.')
+        raise ValueError('one of init_checkpoint/data_path must be chosen.')
 
     if args.do_train and args.save_path is None:
         raise ValueError('Where do you want to save your trained model?')
@@ -259,7 +259,7 @@ def main(args):
             warm_up_steps = checkpoint['warm_up_steps']
             optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
     else:
-        logger.info(f"Ramdomly Initializing {args.model} Model...")
+        logger.info(f"Randomly Initializing {args.model} Model...")
         init_step = 0
 
     step = init_step


### PR DESCRIPTION
This is a large pull request attempting to improve readability issues throughout the Examples repo.

Changes to 40+ files include typos in docs, docstrings and variable names.

When a variable name was changed, I did a global `grep -r var_name` to ensure no dangling references were left.

Feels solid; could use a second pair of eyes before merging.

Thanks!
Ryan