### PR TITLE
[image] replace torchvision resnet with cifar-specific resnet

### DIFF
--- a/image/resnet/README.md
+++ b/image/resnet/README.md
@@ -12,7 +12,7 @@ export DATA=/path/to/data
 
 ## Run single-GPU training
 
-We provide two examples of training resnet 34 on the CIFAR10 dataset. 
+We provide two examples of training resnet 18 on the CIFAR10 dataset. 
 You can change the value of `nproc_per_node` to adjust the number of GPUs used for training. 
 When the `nproc_per_node` is changed, you may need to adjust the learning rate and batch size in the `config.py` accordingly.
 Normally we follow the rule of linear scaling, which is `new_global_batch_size / new_learning_rate = old_global_batch_size / old_learning rate`.
@@ -24,3 +24,9 @@ colossalai run --nproc_per_node 1 train.py
 # with trainer
 colossalai run --nproc_per_node 1 train.py --use_trainer
 ```
+
+## Experiment Results
+
+| model      | dataset     | Testing Accuracy |
+| -          | -           | -                |
+| ResNet18   | CIFAR10     | 95.2%            |

--- a/image/resnet/resnet.py
+++ b/image/resnet/resnet.py
@@ -1,0 +1,129 @@
+'''ResNet in PyTorch.
+
+Reference:
+[1] Kuang Liu, https://github.com/kuangliu/pytorch-cifar/blob/master/models/resnet.py
+[2] Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun
+    Deep Residual Learning for Image Recognition. arXiv:1512.03385
+'''
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class BasicBlock(nn.Module):
+    expansion = 1
+
+    def __init__(self, in_planes, planes, stride=1):
+        super(BasicBlock, self).__init__()
+        self.conv1 = nn.Conv2d(
+            in_planes, planes, kernel_size=3, stride=stride, padding=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(planes)
+        self.conv2 = nn.Conv2d(planes, planes, kernel_size=3,
+                               stride=1, padding=1, bias=False)
+        self.bn2 = nn.BatchNorm2d(planes)
+
+        self.shortcut = nn.Sequential()
+        if stride != 1 or in_planes != self.expansion*planes:
+            self.shortcut = nn.Sequential(
+                nn.Conv2d(in_planes, self.expansion*planes,
+                          kernel_size=1, stride=stride, bias=False),
+                nn.BatchNorm2d(self.expansion*planes)
+            )
+
+    def forward(self, x):
+        out = F.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        out += self.shortcut(x)
+        out = F.relu(out)
+        return out
+
+
+class Bottleneck(nn.Module):
+    expansion = 4
+
+    def __init__(self, in_planes, planes, stride=1):
+        super(Bottleneck, self).__init__()
+        self.conv1 = nn.Conv2d(in_planes, planes, kernel_size=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(planes)
+        self.conv2 = nn.Conv2d(planes, planes, kernel_size=3,
+                               stride=stride, padding=1, bias=False)
+        self.bn2 = nn.BatchNorm2d(planes)
+        self.conv3 = nn.Conv2d(planes, self.expansion *
+                               planes, kernel_size=1, bias=False)
+        self.bn3 = nn.BatchNorm2d(self.expansion*planes)
+
+        self.shortcut = nn.Sequential()
+        if stride != 1 or in_planes != self.expansion*planes:
+            self.shortcut = nn.Sequential(
+                nn.Conv2d(in_planes, self.expansion*planes,
+                          kernel_size=1, stride=stride, bias=False),
+                nn.BatchNorm2d(self.expansion*planes)
+            )
+
+    def forward(self, x):
+        out = F.relu(self.bn1(self.conv1(x)))
+        out = F.relu(self.bn2(self.conv2(out)))
+        out = self.bn3(self.conv3(out))
+        out += self.shortcut(x)
+        out = F.relu(out)
+        return out
+
+
+class ResNet(nn.Module):
+    def __init__(self, block, num_blocks, num_classes=10):
+        super(ResNet, self).__init__()
+        self.in_planes = 64
+
+        self.conv1 = nn.Conv2d(3, 64, kernel_size=3,
+                               stride=1, padding=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(64)
+        self.layer1 = self._make_layer(block, 64, num_blocks[0], stride=1)
+        self.layer2 = self._make_layer(block, 128, num_blocks[1], stride=2)
+        self.layer3 = self._make_layer(block, 256, num_blocks[2], stride=2)
+        self.layer4 = self._make_layer(block, 512, num_blocks[3], stride=2)
+        self.linear = nn.Linear(512*block.expansion, num_classes)
+
+    def _make_layer(self, block, planes, num_blocks, stride):
+        strides = [stride] + [1]*(num_blocks-1)
+        layers = []
+        for stride in strides:
+            layers.append(block(self.in_planes, planes, stride))
+            self.in_planes = planes * block.expansion
+        return nn.Sequential(*layers)
+
+    def forward(self, x):
+        out = F.relu(self.bn1(self.conv1(x)))
+        out = self.layer1(out)
+        out = self.layer2(out)
+        out = self.layer3(out)
+        out = self.layer4(out)
+        out = F.avg_pool2d(out, 4)
+        out = out.view(out.size(0), -1)
+        out = self.linear(out)
+        return out
+
+
+def ResNet18():
+    return ResNet(BasicBlock, [2, 2, 2, 2])
+
+
+def ResNet34():
+    return ResNet(BasicBlock, [3, 4, 6, 3])
+
+
+def ResNet50():
+    return ResNet(Bottleneck, [3, 4, 6, 3])
+
+
+def ResNet101():
+    return ResNet(Bottleneck, [3, 4, 23, 3])
+
+
+def ResNet152():
+    return ResNet(Bottleneck, [3, 8, 36, 3])
+
+
+def test():
+    net = ResNet18()
+    y = net(torch.randn(1, 3, 32, 32))
+    print(y.size())

--- a/image/resnet/train.py
+++ b/image/resnet/train.py
@@ -10,7 +10,7 @@ from colossalai.nn.metric import Accuracy
 from torchvision import transforms
 from colossalai.nn.lr_scheduler import CosineAnnealingLR
 from torchvision.datasets import CIFAR10
-from torchvision.models import resnet34
+from resnet import ResNet18
 from tqdm import tqdm
 from titans.utils import barrier_context
 
@@ -27,7 +27,7 @@ def main():
     logger = get_dist_logger()
 
     # build resnet
-    model = resnet34(num_classes=10)
+    model = ResNet18()
 
     with barrier_context():
         # build dataloaders


### PR DESCRIPTION
The model convergence performance in the ResNet+CIFAR10 example is much lower (below 90% testing accuracy) than the results reported in the ResNet paper. This is because that the author has designed slightly different model architectures for CIFAR and ImageNet experiments. The model provided by `torchvision` is for ImageNet and thus gives poor performance on CIFAR10. I have added CIFAR10-ResNet implementation in this example and produced 95% testing accuracy.